### PR TITLE
Bump actions/upload-artifact@4.4.3

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -33,7 +33,7 @@ jobs:
         run: ./mvnw -B verify -Dmaven.test.failure.ignore=true -Dansi.strip=true
 
       - name: Test Logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.3
         if: success() || failure()
         with:
           name: jdk17-test-results


### PR DESCRIPTION
actions/upload-artifact@v3 is going to be dismissed in 2025